### PR TITLE
feat : 로그인 구현

### DIFF
--- a/src/main/java/com/ohsproject/ohs/member/controller/MemberController.java
+++ b/src/main/java/com/ohsproject/ohs/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.ohsproject.ohs.member.controller;
+
+import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.service.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/member")
+public class MemberController {
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody @Valid final MemberLoginDto memberLoginDto, HttpSession httpSession) {
+        memberService.login(memberLoginDto, httpSession);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/member/dto/request/MemberLoginDto.java
+++ b/src/main/java/com/ohsproject/ohs/member/dto/request/MemberLoginDto.java
@@ -1,0 +1,18 @@
+package com.ohsproject.ohs.member.dto.request;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class MemberLoginDto {
+    @NotNull
+    private Long id;
+
+    private MemberLoginDto() {
+    }
+
+    public MemberLoginDto(final Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/member/service/MemberService.java
+++ b/src/main/java/com/ohsproject/ohs/member/service/MemberService.java
@@ -1,0 +1,33 @@
+package com.ohsproject.ohs.member.service;
+
+import com.ohsproject.ohs.member.domain.Member;
+import com.ohsproject.ohs.member.domain.MemberRepository;
+import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.exception.MemberNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpSession;
+import java.util.UUID;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public void login(MemberLoginDto memberLoginDto, HttpSession httpSession) {
+        Member member = findMemberById(memberLoginDto.getId());
+        String sessionId = UUID.randomUUID().toString();
+
+        httpSession.setAttribute(sessionId, member);
+    }
+
+    private Member findMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/ohsproject/ohs/order/dto/request/OrderCreateRequest.java
@@ -12,13 +12,16 @@ import java.util.Objects;
 @Getter
 public class OrderCreateRequest {
     @NotNull
-    private final Long memberId;
+    private Long memberId;
     @NotNull
-    private final List<Long> productIds;
+    private List<Long> productIds;
     @NotNull
-    private final List<Integer> quantities;
+    private List<Integer> quantities;
     @NotNull
-    private final int amount;
+    private int amount;
+
+    private OrderCreateRequest() {
+    }
 
     public OrderCreateRequest(final Long memberId, final List<Long> productIds, final List<Integer> quantities, final int amount) {
         this.memberId = memberId;

--- a/src/test/java/com/ohsproject/ohs/member/MemberControllerTest.java
+++ b/src/test/java/com/ohsproject/ohs/member/MemberControllerTest.java
@@ -1,0 +1,77 @@
+package com.ohsproject.ohs.member;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ohsproject.ohs.member.controller.MemberController;
+import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+public class MemberControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MemberService memberService;
+
+    final ObjectMapper objectMapper;
+
+    private static final long MEMBER_ID = 1L;
+
+    public MemberControllerTest() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("로그인 api 호출 성공")
+    void success_login() throws Exception {
+        // given
+        MemberLoginDto memberLoginDto = createSampleMemberLoginDto();
+        MockHttpSession session = new MockHttpSession();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/member/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .session(session)
+                        .content(objectMapper.writeValueAsString(memberLoginDto))
+        );
+
+        // then
+        resultActions.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("잘못된 ID로 로그인 시 실패")
+    void unSuccess_login() throws Exception {
+        // given
+        MemberLoginDto memberLoginDto = new MemberLoginDto(null);
+        MockHttpSession session = new MockHttpSession();
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/v1/member/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .session(session)
+                        .content(objectMapper.writeValueAsString(memberLoginDto))
+        );
+
+        // then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    private MemberLoginDto createSampleMemberLoginDto() {
+        return new MemberLoginDto(MEMBER_ID);
+    }
+}

--- a/src/test/java/com/ohsproject/ohs/member/MemberServiceTest.java
+++ b/src/test/java/com/ohsproject/ohs/member/MemberServiceTest.java
@@ -1,0 +1,69 @@
+package com.ohsproject.ohs.member;
+
+import com.ohsproject.ohs.member.domain.Member;
+import com.ohsproject.ohs.member.domain.MemberRepository;
+import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.exception.MemberNotFoundException;
+import com.ohsproject.ohs.member.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpSession;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    private static final long MEMBER_ID = 1L;
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login() {
+        // given
+        Member member = createSampleMember();
+        MemberLoginDto memberLoginDto = createSampleMemberLoginDto();
+        MockHttpSession session = new MockHttpSession();
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+
+        // when
+        memberService.login(memberLoginDto, session);
+
+        // then
+        verify(memberRepository, times(1)).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("잘못된 아이디로 로그인하는 경우")
+    void login_MemberNotFound() {
+        // given
+        MemberLoginDto memberLoginDto = createSampleMemberLoginDto();
+        MockHttpSession session = new MockHttpSession();
+        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // when, then
+        assertThrows(MemberNotFoundException.class, () -> memberService.login(memberLoginDto, session));
+    }
+
+
+    private Member createSampleMember() {
+        return new Member(MEMBER_ID, "test");
+    }
+
+    private MemberLoginDto createSampleMemberLoginDto() {
+        return new MemberLoginDto(MEMBER_ID);
+    }
+
+}


### PR DESCRIPTION
Closes : #6 
 
작업 내용 :
1. 로그인 api에 사용될 dto 생성
2. 로그인 비지니스 로직 작성
3. 로그인 api 구현
4. 로그인 로직 및 api에 대한 테스트 추가