### PR TITLE
feat : 공유 세션 저장소 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ohsproject/ohs/global/exception/SessionNotValidException.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/SessionNotValidException.java
@@ -1,0 +1,8 @@
+package com.ohsproject.ohs.global.exception;
+
+public class SessionNotValidException extends RuntimeException {
+
+    public SessionNotValidException() {
+        super("세션이 유효하지 않습니다.");
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/member/controller/MemberController.java
+++ b/src/main/java/com/ohsproject/ohs/member/controller/MemberController.java
@@ -1,12 +1,9 @@
 package com.ohsproject.ohs.member.controller;
 
-import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.dto.request.MemberLoginRequest;
 import com.ohsproject.ohs.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
@@ -21,9 +18,10 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Void> login(@RequestBody @Valid final MemberLoginDto memberLoginDto, HttpSession httpSession) {
-        memberService.login(memberLoginDto, httpSession);
+    public ResponseEntity<Void> login(@RequestBody @Valid final MemberLoginRequest memberLoginRequest, HttpSession httpSession) {
+        memberService.login(memberLoginRequest, httpSession);
 
         return ResponseEntity.ok().build();
     }
+
 }

--- a/src/main/java/com/ohsproject/ohs/member/dto/request/MemberLoginRequest.java
+++ b/src/main/java/com/ohsproject/ohs/member/dto/request/MemberLoginRequest.java
@@ -5,14 +5,14 @@ import lombok.Getter;
 import javax.validation.constraints.NotNull;
 
 @Getter
-public class MemberLoginDto {
+public class MemberLoginRequest {
     @NotNull
     private Long id;
 
-    private MemberLoginDto() {
+    private MemberLoginRequest() {
     }
 
-    public MemberLoginDto(final Long id) {
+    public MemberLoginRequest(final Long id) {
         this.id = id;
     }
 }

--- a/src/main/java/com/ohsproject/ohs/member/service/MemberService.java
+++ b/src/main/java/com/ohsproject/ohs/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.ohsproject.ohs.member.service;
 
 import com.ohsproject.ohs.member.domain.Member;
 import com.ohsproject.ohs.member.domain.MemberRepository;
-import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.dto.request.MemberLoginRequest;
 import com.ohsproject.ohs.member.exception.MemberNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,10 +18,10 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
-    public void login(MemberLoginDto memberLoginDto, HttpSession httpSession) {
-        Member member = findMemberById(memberLoginDto.getId());
+    public void login(MemberLoginRequest memberLoginRequest, HttpSession httpSession) {
+        Member member = findMemberById(memberLoginRequest.getId());
 
-        httpSession.setAttribute("member", member);
+        httpSession.setAttribute("memberId", member.getId());
     }
 
     private Member findMemberById(Long id) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,22 @@ spring:
   sql:
     init:
       data-locations: classpath:data.sql
+
+  redis:
+    host: localhost
+    port: 6379
+    #password:
+  session:
+    store-type: redis
+    #redis:
+      #namespace: test:session
+
+server:
+  servlet:
+    session:
+      cookie:
+        path: /
+        name: JSESSIONID
+        domain: localhost
+        http-only: true
+      timeout: 3600

--- a/src/test/java/com/ohsproject/ohs/member/MemberControllerTest.java
+++ b/src/test/java/com/ohsproject/ohs/member/MemberControllerTest.java
@@ -2,7 +2,7 @@ package com.ohsproject.ohs.member;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ohsproject.ohs.member.controller.MemberController;
-import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.dto.request.MemberLoginRequest;
 import com.ohsproject.ohs.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ public class MemberControllerTest {
     @DisplayName("로그인 api 호출 성공")
     void success_login() throws Exception {
         // given
-        MemberLoginDto memberLoginDto = createSampleMemberLoginDto();
+        MemberLoginRequest memberLoginRequest = createSampleMemberLoginDto();
         MockHttpSession session = new MockHttpSession();
 
         // when
@@ -45,7 +45,7 @@ public class MemberControllerTest {
                 post("/api/v1/member/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .session(session)
-                        .content(objectMapper.writeValueAsString(memberLoginDto))
+                        .content(objectMapper.writeValueAsString(memberLoginRequest))
         );
 
         // then
@@ -56,7 +56,7 @@ public class MemberControllerTest {
     @DisplayName("잘못된 ID로 로그인 시 실패")
     void unSuccess_login() throws Exception {
         // given
-        MemberLoginDto memberLoginDto = new MemberLoginDto(null);
+        MemberLoginRequest memberLoginRequest = new MemberLoginRequest(null);
         MockHttpSession session = new MockHttpSession();
 
         // when
@@ -64,14 +64,14 @@ public class MemberControllerTest {
                 post("/api/v1/member/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .session(session)
-                        .content(objectMapper.writeValueAsString(memberLoginDto))
+                        .content(objectMapper.writeValueAsString(memberLoginRequest))
         );
 
         // then
         resultActions.andExpect(status().isBadRequest());
     }
 
-    private MemberLoginDto createSampleMemberLoginDto() {
-        return new MemberLoginDto(MEMBER_ID);
+    private MemberLoginRequest createSampleMemberLoginDto() {
+        return new MemberLoginRequest(MEMBER_ID);
     }
 }

--- a/src/test/java/com/ohsproject/ohs/member/MemberServiceTest.java
+++ b/src/test/java/com/ohsproject/ohs/member/MemberServiceTest.java
@@ -2,7 +2,7 @@ package com.ohsproject.ohs.member;
 
 import com.ohsproject.ohs.member.domain.Member;
 import com.ohsproject.ohs.member.domain.MemberRepository;
-import com.ohsproject.ohs.member.dto.request.MemberLoginDto;
+import com.ohsproject.ohs.member.dto.request.MemberLoginRequest;
 import com.ohsproject.ohs.member.exception.MemberNotFoundException;
 import com.ohsproject.ohs.member.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
@@ -34,12 +34,12 @@ public class MemberServiceTest {
     void login() {
         // given
         Member member = createSampleMember();
-        MemberLoginDto memberLoginDto = createSampleMemberLoginDto();
+        MemberLoginRequest memberLoginRequest = createSampleMemberLoginDto();
         MockHttpSession session = new MockHttpSession();
         when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
 
         // when
-        memberService.login(memberLoginDto, session);
+        memberService.login(memberLoginRequest, session);
 
         // then
         verify(memberRepository, times(1)).findById(anyLong());
@@ -49,12 +49,12 @@ public class MemberServiceTest {
     @DisplayName("잘못된 아이디로 로그인하는 경우")
     void login_MemberNotFound() {
         // given
-        MemberLoginDto memberLoginDto = createSampleMemberLoginDto();
+        MemberLoginRequest memberLoginRequest = createSampleMemberLoginDto();
         MockHttpSession session = new MockHttpSession();
         when(memberRepository.findById(1L)).thenReturn(Optional.empty());
 
         // when, then
-        assertThrows(MemberNotFoundException.class, () -> memberService.login(memberLoginDto, session));
+        assertThrows(MemberNotFoundException.class, () -> memberService.login(memberLoginRequest, session));
     }
 
 
@@ -62,8 +62,8 @@ public class MemberServiceTest {
         return new Member(MEMBER_ID, "test");
     }
 
-    private MemberLoginDto createSampleMemberLoginDto() {
-        return new MemberLoginDto(MEMBER_ID);
+    private MemberLoginRequest createSampleMemberLoginDto() {
+        return new MemberLoginRequest(MEMBER_ID);
     }
 
 }


### PR DESCRIPTION
Closes : #12 

작업 내용 : 
1. 유효하지 않는 세션에 대해 커스텀 예외 구현
2. 세션 조회 및 생성 과정 일부 수정 
3. 세션 관리를 효과적으로 처리하기 위해 Spring session 도입
4. Spring session에서 지원하는 저장소 중 속도 면에서 뛰어난 Redis를 세션 저장소로 선택
5. 관련한 일부 테스트 코드 수정