### PR TITLE
feat : 예외 핸들러 구현

### DIFF
--- a/src/main/java/com/ohsproject/ohs/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/ohsproject/ohs/auth/dto/request/LoginRequest.java
@@ -6,7 +6,7 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 public class LoginRequest {
-    @NotNull
+    @NotNull(message = "아이디를 입력해주세요.")
     private Long id;
 
     private LoginRequest() {

--- a/src/main/java/com/ohsproject/ohs/auth/exception/DuplicateLoginException.java
+++ b/src/main/java/com/ohsproject/ohs/auth/exception/DuplicateLoginException.java
@@ -1,7 +1,9 @@
 package com.ohsproject.ohs.auth.exception;
 
-public class DuplicateLoginException extends RuntimeException{
+import com.ohsproject.ohs.global.exception.custom.BadRequestException;
+
+public class DuplicateLoginException extends BadRequestException {
     public DuplicateLoginException() {
-        super("중복된 로그인.");
+        super("로그인은 한 번만 할 수 있습니다.");
     }
 }

--- a/src/main/java/com/ohsproject/ohs/auth/exception/SessionNotValidException.java
+++ b/src/main/java/com/ohsproject/ohs/auth/exception/SessionNotValidException.java
@@ -1,6 +1,8 @@
 package com.ohsproject.ohs.auth.exception;
 
-public class SessionNotValidException extends RuntimeException {
+import com.ohsproject.ohs.global.exception.custom.UnauthorizedException;
+
+public class SessionNotValidException extends UnauthorizedException {
 
     public SessionNotValidException() {
         super("세션이 유효하지 않습니다.");

--- a/src/main/java/com/ohsproject/ohs/global/exception/custom/BadRequestException.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/custom/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.ohsproject.ohs.global.exception.custom;
+
+public class BadRequestException extends CustomException {
+
+    private static final String STATUS_CODE = "400";
+
+    public BadRequestException(String message) {
+        super(STATUS_CODE, message);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/global/exception/custom/ConflictException.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/custom/ConflictException.java
@@ -1,0 +1,10 @@
+package com.ohsproject.ohs.global.exception.custom;
+
+public class ConflictException extends CustomException {
+
+    private static final String STATUS_CODE = "409";
+
+    public ConflictException(String message) {
+        super(STATUS_CODE, message);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/global/exception/custom/CustomException.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/custom/CustomException.java
@@ -1,0 +1,13 @@
+package com.ohsproject.ohs.global.exception.custom;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final String code;
+
+    public CustomException(String code, String message) {
+        super(message);
+        this.code = code;
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/global/exception/custom/ForbiddenException.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/custom/ForbiddenException.java
@@ -1,0 +1,10 @@
+package com.ohsproject.ohs.global.exception.custom;
+
+public class ForbiddenException extends CustomException {
+
+    private static final String STATUS_CODE = "403";
+
+    public ForbiddenException(String message) {
+        super(STATUS_CODE, message);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/global/exception/custom/NotFoundException.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/custom/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.ohsproject.ohs.global.exception.custom;
+
+public class NotFoundException extends CustomException {
+
+    private static final String STATUS_CODE = "404";
+
+    public NotFoundException(String message) {
+        super(STATUS_CODE, message);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/global/exception/custom/UnauthorizedException.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/custom/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package com.ohsproject.ohs.global.exception.custom;
+
+public class UnauthorizedException extends CustomException{
+
+    private static final String STATUS_CODE = "401";
+
+    public UnauthorizedException(String message) {
+        super(STATUS_CODE, message);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/global/exception/handler/ExceptionHandleAdvice.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/handler/ExceptionHandleAdvice.java
@@ -1,0 +1,43 @@
+package com.ohsproject.ohs.global.exception.handler;
+
+import com.ohsproject.ohs.global.exception.custom.CustomException;
+import com.ohsproject.ohs.global.exception.reponse.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionHandleAdvice {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionResponse> handleCustomException(final CustomException e) {
+        log.error(e.toString());
+        return ResponseEntity
+                .status(HttpStatus.valueOf(Integer.parseInt(e.getCode())))
+                .body(ExceptionResponse.from(e));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleValidationException(final MethodArgumentNotValidException e) {
+        log.error(e.toString());
+
+        ExceptionResponse exceptionResponse = ExceptionResponse.from("400", "잘못된 요청입니다.");
+        for (FieldError fieldError : e.getFieldErrors()) {
+            exceptionResponse.addFieldError(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        return ResponseEntity.badRequest().body(exceptionResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleUnhandledException(final Exception e) {
+        log.error(e.toString());
+        ExceptionResponse exceptionResponse = ExceptionResponse.from("500", e.getMessage());
+        return ResponseEntity.internalServerError().body(exceptionResponse);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/global/exception/reponse/ExceptionResponse.java
+++ b/src/main/java/com/ohsproject/ohs/global/exception/reponse/ExceptionResponse.java
@@ -1,0 +1,35 @@
+package com.ohsproject.ohs.global.exception.reponse;
+
+import com.ohsproject.ohs.global.exception.custom.CustomException;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class ExceptionResponse {
+    private String code;
+    private String message;
+    private Map<String, String> fieldErrors;
+
+    private ExceptionResponse() {
+    }
+
+    private ExceptionResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+        this.fieldErrors = new HashMap<>();
+    }
+
+    public static ExceptionResponse from(CustomException e) {
+        return new ExceptionResponse(e.getCode(), e.getMessage());
+    }
+
+    public static ExceptionResponse from(String code, String message) {
+        return new ExceptionResponse(code, message);
+    }
+
+    public void addFieldError(String field, String message) {
+        fieldErrors.put(field, message);
+    }
+}

--- a/src/main/java/com/ohsproject/ohs/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/ohsproject/ohs/member/exception/MemberNotFoundException.java
@@ -1,6 +1,8 @@
 package com.ohsproject.ohs.member.exception;
 
-public class MemberNotFoundException extends RuntimeException {
+import com.ohsproject.ohs.global.exception.custom.NotFoundException;
+
+public class MemberNotFoundException extends NotFoundException {
     public MemberNotFoundException() {
         super("회원을 찾을 수 없습니다.");
     }

--- a/src/main/java/com/ohsproject/ohs/order/dto/request/OrderCompleteRequest.java
+++ b/src/main/java/com/ohsproject/ohs/order/dto/request/OrderCompleteRequest.java
@@ -7,7 +7,8 @@ import java.util.List;
 
 @Getter
 public class OrderCompleteRequest {
-    @NotNull
+
+    @NotNull(message = "잘못된 요청입니다.")
     private List<OrderDetailRequest> orderDetailRequests;
 
     private int amount;

--- a/src/main/java/com/ohsproject/ohs/order/dto/request/OrderCreateRequest.java
+++ b/src/main/java/com/ohsproject/ohs/order/dto/request/OrderCreateRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Getter
 public class OrderCreateRequest {
 
-    @NotNull
+    @NotNull(message = "상품을 선택해 주세요.")
     private List<OrderDetailRequest> orderDetailRequests;
 
     private int amount;

--- a/src/main/java/com/ohsproject/ohs/order/dto/request/OrderDetailRequest.java
+++ b/src/main/java/com/ohsproject/ohs/order/dto/request/OrderDetailRequest.java
@@ -6,7 +6,8 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 public class OrderDetailRequest {
-    @NotNull
+
+    @NotNull(message = "상품을 선택해 주세요.")
     private Long productId;
 
     private int qty;

--- a/src/main/java/com/ohsproject/ohs/order/exception/OrderNotFoundException.java
+++ b/src/main/java/com/ohsproject/ohs/order/exception/OrderNotFoundException.java
@@ -1,6 +1,8 @@
 package com.ohsproject.ohs.order.exception;
 
-public class OrderNotFoundException extends RuntimeException {
+import com.ohsproject.ohs.global.exception.custom.NotFoundException;
+
+public class OrderNotFoundException extends NotFoundException {
 
     public OrderNotFoundException() {
         super("해당 주문을 찾을 수 없습니다.");

--- a/src/main/java/com/ohsproject/ohs/order/exception/OrderNotValidException.java
+++ b/src/main/java/com/ohsproject/ohs/order/exception/OrderNotValidException.java
@@ -1,6 +1,8 @@
 package com.ohsproject.ohs.order.exception;
 
-public class OrderNotValidException extends RuntimeException {
+import com.ohsproject.ohs.global.exception.custom.BadRequestException;
+
+public class OrderNotValidException extends BadRequestException {
 
     public OrderNotValidException() {
         super("잘못된 주문에 대한 요청입니다.");

--- a/src/main/java/com/ohsproject/ohs/product/exception/InsufficientStockException.java
+++ b/src/main/java/com/ohsproject/ohs/product/exception/InsufficientStockException.java
@@ -1,6 +1,8 @@
 package com.ohsproject.ohs.product.exception;
 
-public class InsufficientStockException extends RuntimeException {
+import com.ohsproject.ohs.global.exception.custom.BadRequestException;
+
+public class InsufficientStockException extends BadRequestException {
     public InsufficientStockException() {
         super("재고량이 부족합니다.");
     }

--- a/src/main/java/com/ohsproject/ohs/product/exception/ProductNotFoundException.java
+++ b/src/main/java/com/ohsproject/ohs/product/exception/ProductNotFoundException.java
@@ -1,6 +1,8 @@
 package com.ohsproject.ohs.product.exception;
 
-public class ProductNotFoundException extends RuntimeException {
+import com.ohsproject.ohs.global.exception.custom.NotFoundException;
+
+public class ProductNotFoundException extends NotFoundException {
 
     public ProductNotFoundException() {
         super("상품을 찾을 수 없습니다.");

--- a/src/test/java/com/ohsproject/ohs/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/ohsproject/ohs/auth/controller/AuthControllerTest.java
@@ -13,6 +13,11 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import javax.servlet.http.HttpSession;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,6 +42,7 @@ public class AuthControllerTest {
         // given
         LoginRequest loginRequest = new LoginRequest(1L);
         MockHttpSession session = new MockHttpSession();
+        doNothing().when(authService).login(any(LoginRequest.class), any(HttpSession.class));
 
         // when
         ResultActions resultActions = mockMvc.perform(
@@ -49,6 +55,7 @@ public class AuthControllerTest {
         // then
         resultActions.andExpect(status().isOk())
                 .andDo(print());
+        verify(authService).login(any(LoginRequest.class), any(HttpSession.class));
     }
 
     @Test
@@ -67,6 +74,7 @@ public class AuthControllerTest {
         );
 
         // then
-        resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(status().isBadRequest())
+                .andDo(print());;
     }
 }


### PR DESCRIPTION
Closes : #26 

작업 내용 : 
1. 상위 계층 커스텀 예외 구현
RuntimeException을 확장한 CustomException 구현
CustomException을 확장하는 상태코드별 예외 구현
2. 커스텀 예외 계층 구조 변경
기존 각각 예외에 대해 RuntimeException을 확장하는 구조에서
각 예외에 알맞은 상태코드에 맞도록 커스텀 예외 구현
(as-is : RuntimeException - ProductNotFoundException)
(to-be : RuntimeException - CustomException - NotFoundException - ProductNotFoundException)
3. 예외 핸들러 구현
서비스 전역에서 발생하는 예외를 처리하는 핸들러 구현
'@RestControllerAdvice'와 '@ExceptionHandl er'를 활용
예외 발생 시 조금 더 구체적인 상태코드와 메시지 등 데이터를 전달할 수 있게됨